### PR TITLE
do hipe compilation only if configured in app env

### DIFF
--- a/lib/jazz/parser.ex
+++ b/lib/jazz/parser.ex
@@ -19,7 +19,7 @@ defmodule Jazz.Parser do
   See: http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf
   """
 
-  @compile :native
+  if Application.get_env(:jazz, :native), do: @compile :native
 
   alias Jazz.SyntaxError
 


### PR DESCRIPTION
This pull request makes HiPE compilation an opt-in. To compile Jazz with HiPE, one must include `jazz: [native: true]` in `config.exs` of the depending project (the one that uses Jazz). 

If you don't like this approach, ping me on IRC to discuss whether something else might work. In any case, I don't think HiPE should be used by default.
